### PR TITLE
Add PowerLoss error code and related telemetry

### DIFF
--- a/specification/error_codes/definitions.rst
+++ b/specification/error_codes/definitions.rst
@@ -1,0 +1,37 @@
+..
+   SPDX-License-Identifier: CC-BY-4.0
+   Copyright CharIN e.V. and Contributors
+
+#############
+ Error Codes
+#############
+
+This section defines the error codes.
+
+.. _error_gridpowerloss:
+
+**************
+ GridPowerLoss
+**************
+
+Description
+===========
+
+This error is raised when the charging station experiences a partial or
+complete loss of grid power supply.
+
+Trigger Conditions
+==================
+
+-  The power supply voltage at Side A or Side B of the EVSE drops below a
+   critical threshold as described by the manufacturer.
+
+Related Telemetry
+=================
+
+The following telemetry signals are required for analyzing this error:
+
+-  :ref:`telemetry_communication_state`
+-  :ref:`telemetry_supply_voltage_l1`
+-  :ref:`telemetry_supply_voltage_l2`
+-  :ref:`telemetry_supply_voltage_l3`

--- a/specification/index.rst
+++ b/specification/index.rst
@@ -1,10 +1,17 @@
-.. SPDX-License-Identifier: CC-BY-4.0
-.. Copyright CharIN e.V. and Contributors
+..
+   SPDX-License-Identifier: CC-BY-4.0
+   Copyright CharIN e.V. and Contributors
 
-Unified Error Codes documentation
-=================================
+#####################
+ Unified Error Codes
+#####################
+
+This document specifies a unified set of error codes and telemetry signals
+for electric vehicle charging stations.
 
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
 
+   error_codes/definitions
+   telemetry/definitions

--- a/specification/telemetry/definitions.rst
+++ b/specification/telemetry/definitions.rst
@@ -1,0 +1,73 @@
+..
+   SPDX-License-Identifier: CC-BY-4.0
+   Copyright CharIN e.V. and Contributors
+
+###########
+ Telemetry
+###########
+
+This section defines the telemetry signals that shall be monitored by
+the charging station.
+
+.. _telemetry_supply_voltage_l1:
+
+*******************
+ Supply Voltage L1
+*******************
+
+-  **Description**: The continuous measurement of AC voltage for L1
+   phase. Measured at Side A of the EVSE as defined in IEC 61851-23:2023
+   sections 3.7.102 and 3.7.103.
+-  **Unit**: Volts (V)
+-  **Resolution**: `1 V`
+
+.. _telemetry_supply_voltage_l2:
+
+*******************
+ Supply Voltage L2
+*******************
+
+-  **Description**: The continuous measurement of AC voltage for L2
+   phase. Measured at Side A of the EVSE as defined in IEC 61851-23:2023
+   sections 3.7.102 and 3.7.103.
+-  **Unit**: Volts (V)
+-  **Resolution**: `1 V`
+
+.. _telemetry_supply_voltage_l3:
+
+*******************
+ Supply Voltage L3
+*******************
+
+-  **Description**: The continuous measurement of AC voltage for L3
+   phase. Measured at Side A of the EVSE as defined in IEC 61851-23:2023
+   sections 3.7.102 and 3.7.103.
+-  **Unit**: Volts (V)
+-  **Resolution**: `1 V`
+
+.. _telemetry_communication_state:
+
+********************
+ Communication State
+********************
+
+-  **Description**: The state of the communication between EV and charging station.
+-  **Unit**: N/A
+-  **Resolution**: N/A
+-  **Source**: DIN DKE SPEC 99003:2024-10, Table 17 — CommunicationStateType parameter
+-  **Values**:
+
+   -  ``SLAC`` — Error occurred during SLAC.
+   -  ``SDP`` — Error occurred during SDP.
+   -  ``CommunicationSetup`` — Error occurred during CommunicationSetup.
+   -  ``ServiceDiscovery`` — Error occurred during ServiceDiscovery.
+   -  ``PaymentSelection`` — Error occurred during PaymentSelection.
+   -  ``CertificateInstallation`` — Error occurred during CertificateInstallation.
+   -  ``CertificateUpdate`` — Error occurred during CertificateUpdate.
+   -  ``Authorization`` — Error occurred during Authorization.
+   -  ``ChargeParameterDiscovery`` — Error occurred during ChargeParameterDiscovery.
+   -  ``CableCheck`` — Error occurred during CableCheck.
+   -  ``PreCharge`` — Error occurred during PreCharge.
+   -  ``CurrentDemand`` — Error occurred during CurrentDemand.
+   -  ``WeldingDetection`` — Error occurred during WeldingDetection.
+   -  ``SessionStop`` — Error occurred during SessionStop.


### PR DESCRIPTION
Add PowerLoss error code and related telemetry

This commit introduces the definition for the `PowerLoss` error code.
It also adds the definition for input voltage telemetry data, which is
associated with this error.

Closes: #2 