### PR TITLE
feat: add ConnectorLockFailure error code and related telemetry

### DIFF
--- a/specification/error_codes/definitions.rst
+++ b/specification/error_codes/definitions.rst
@@ -1,0 +1,65 @@
+..
+   SPDX-License-Identifier: CC-BY-4.0
+   Copyright CharIN e.V. and Contributors
+
+#############
+ Error Codes
+#############
+
+This section defines the error codes.
+
+.. _error_powerloss:
+
+***********
+ PowerLoss
+***********
+
+Description
+===========
+
+This error is raised when the charging station experiences a partial or
+complete loss of its main power supply.
+
+Trigger Conditions
+==================
+
+-  The main power supply voltage drops below a threshold that prevents the charging station from operating.
+
+Related Telemetry
+=================
+
+The following telemetry signals are required for analyzing this error:
+
+-  :ref:`telemetry_communication_state`
+-  :ref:`telemetry_supply_voltage_l1`
+-  :ref:`telemetry_supply_voltage_l2`
+-  :ref:`telemetry_supply_voltage_l3`
+
+.. _error_connectorlockfailure:
+
+**********************
+ ConnectorLockFailure
+**********************
+
+Description
+===========
+
+This error is raised when the CCS connector lock mechanism fails to reach
+the expected locked or unlocked position. The latch is mechanically engaged
+by the EV, but lock state is observable from the EVSE via position feedback.
+
+Trigger Conditions
+==================
+
+-  The lock position feedback does not reach the locked threshold within the
+   expected time after a lock command is issued.
+-  The lock position feedback does not reach the unlocked threshold within the
+   expected time after an unlock command is issued.
+
+Related Telemetry
+=================
+
+The following telemetry signals are required for analyzing this error:
+
+-  :ref:`telemetry_connector_lock_position`
+-  :ref:`telemetry_connector_lock_command`

--- a/specification/telemetry/definitions.rst
+++ b/specification/telemetry/definitions.rst
@@ -1,0 +1,78 @@
+..
+   SPDX-License-Identifier: CC-BY-4.0
+   Copyright CharIN e.V. and Contributors
+
+###########
+ Telemetry
+###########
+
+This section defines the telemetry signals that shall be monitored by
+the charging station.
+
+.. _telemetry_supply_voltage_l1:
+
+*******************
+ Supply Voltage L1
+*******************
+
+-  **Description**: The continuous measurement of AC voltage for L1
+   phase. Measured at the AC supply input to the charging station.
+-  **Unit**: Volts (V)
+-  **Resolution**: `1 V`
+
+.. _telemetry_supply_voltage_l2:
+
+*******************
+ Supply Voltage L2
+*******************
+
+-  **Description**: The continuous measurement of AC voltage for L2
+   phase. Measured at the AC supply input to the charging station.
+-  **Unit**: Volts (V)
+-  **Resolution**: `1 V`
+
+.. _telemetry_supply_voltage_l3:
+
+*******************
+ Supply Voltage L3
+*******************
+
+-  **Description**: The continuous measurement of AC voltage for L3
+   phase. Measured at the AC supply input to the charging station.
+-  **Unit**: Volts (V)
+-  **Resolution**: `1 V`
+
+.. _telemetry_communication_state:
+
+********************
+ Communication State
+********************
+
+-  **Description**: The state of the communication between EV and charging station.
+-  **Unit**: N/A
+-  **Resolution**: N/A
+
+.. _telemetry_connector_lock_position:
+
+************************
+ Connector Lock Position
+************************
+
+-  **Description**: The position feedback state of the CCS connector lock
+   mechanism as reported by the EVSE. Determined by a threshold-based
+   evaluation of the lock actuator feedback signal, which may be a continuous
+   analog measurement.
+-  **Unit**: N/A (enumerated: ``locked``, ``unlocked``, ``unknown``)
+-  **Resolution**: N/A
+
+.. _telemetry_connector_lock_command:
+
+***********************
+ Connector Lock Command
+***********************
+
+-  **Description**: The last command issued to the connector lock actuator
+   by the EVSE. Used to correlate commanded state against reported position
+   feedback during failure analysis.
+-  **Unit**: N/A (enumerated: ``lock``, ``unlock``)
+-  **Resolution**: N/A


### PR DESCRIPTION
## Summary

Adds the `ConnectorLockFailure` error code and two supporting telemetry signals as defined in issue #3.

## Changes

**`specification/error_codes/definitions.rst`**
- Adds `ConnectorLockFailure` error code with description, two trigger conditions (failed lock and failed unlock), and related telemetry references

**`specification/telemetry/definitions.rst`**
- Adds `Connector Lock Position` — threshold-based enumerated feedback state (`locked` / `unlocked` / `unknown`)
- Adds `Connector Lock Command` — last actuator command issued (`lock` / `unlock`), required to distinguish lock vs. unlock failure direction

Closes #3