### PR TITLE
Add ConnectorLockFailure error code and related telemetry

### DIFF
--- a/specification/error_codes/definitions.rst
+++ b/specification/error_codes/definitions.rst
@@ -38,3 +38,4 @@ The following telemetry signals are required for analyzing this error:
 
 .. include:: definitions_EVShiftPosition.rst
 .. include:: definitions_ContactorPosition.rst
+.. include:: definitions_ConnectorLockFailure.rst

--- a/specification/error_codes/definitions_ConnectorLockFailure.rst
+++ b/specification/error_codes/definitions_ConnectorLockFailure.rst
@@ -1,0 +1,36 @@
+..
+   SPDX-License-Identifier: CC-BY-4.0
+   Copyright CharIN e.V. and Contributors
+
+.. _error_connectorlockfailure:
+
+**********************
+ ConnectorLockFailure
+**********************
+
+Description
+===========
+
+This error is raised when the connector lock mechanism fails to reach
+ the expected locked or unlocked position.
+
+This error code is applicable to and can be set by either the EV or EVSE,
+depending on which side owns the lock actuation and monitoring. This allows
+the same definition and criteria to be used for both EV and EVSE.
+
+Trigger Conditions
+==================
+
+-  The lock position feedback does not reach the locked threshold within the
+   expected time after a lock command is issued.
+-  The lock position feedback does not reach the unlocked threshold within the
+   expected time after an unlock command is issued.
+-  The lock position spuriously changes state without a corresponding command.
+
+Related Telemetry
+=================
+
+The following telemetry signals are required for analyzing this error:
+
+-  :ref:`telemetry_connector_lock_position`
+-  :ref:`telemetry_connector_lock_command`

--- a/specification/telemetry/definitions.rst
+++ b/specification/telemetry/definitions.rst
@@ -71,3 +71,5 @@ the charging station.
    -  ``CurrentDemand`` — Error occurred during CurrentDemand.
    -  ``WeldingDetection`` — Error occurred during WeldingDetection.
    -  ``SessionStop`` — Error occurred during SessionStop.
+
+.. include:: definitions_ConnectorLockTelemetry.rst

--- a/specification/telemetry/definitions_ConnectorLockTelemetry.rst
+++ b/specification/telemetry/definitions_ConnectorLockTelemetry.rst
@@ -1,0 +1,28 @@
+..
+   SPDX-License-Identifier: CC-BY-4.0
+   Copyright CharIN e.V. and Contributors
+
+.. _telemetry_connector_lock_position:
+
+************************
+ Connector Lock Position
+************************
+
+-  **Description**: The current position of the connector lock mechanism. The state is
+   determined by evaluating the lock actuator's feedback signal against defined
+   thresholds.
+-  **Values**: locked, unlocked, unknown
+-  **Unit**: N/A
+-  **Resolution**: N/A
+
+.. _telemetry_connector_lock_command:
+
+***********************
+ Connector Lock Command
+***********************
+
+-  **Description**: Used to correlate the commanded state with the reported position
+   feedback for failure analysis.
+-  **Values**: lock, unlock, none
+-  **Unit**: N/A
+-  **Resolution**: N/A


### PR DESCRIPTION
## Summary

Adds the `ConnectorLockFailure` error code and two supporting telemetry signals as defined in issue #3.

## Changes

**`specification/error_codes/definitions_ConnectorLockFailure.rst`**
- Adds `ConnectorLockFailure` error code with description, two trigger conditions (failed lock and failed unlock), and related telemetry references

**`specification/telemetry/definitions_ConnectorLockTelemetry.rst`**
- Adds `Connector Lock Position` — threshold-based enumerated feedback state (`locked` / `unlocked` / `unknown`)
- Adds `Connector Lock Command` — last actuator command issued (`lock` / `unlock`), required to distinguish lock vs. unlock failure direction

Closes #3