### PR TITLE
Definitions updated contactor connector april17 2026

### DIFF
--- a/specification/error_codes/definitions_ContactorPosition.rst
+++ b/specification/error_codes/definitions_ContactorPosition.rst
@@ -2,13 +2,7 @@
    SPDX-License-Identifier: CC-BY-4.0
    Copyright CharIN e.V. and Contributors
 
-#############
- Error Codes
-#############
-
-This section defines the error codes.
-
-.. _error_ContactorPosition:
+.. _error_contactorposition:
 
 ******************
  ContactorPosition
@@ -23,7 +17,7 @@ within the EVSE that manages power flow between the grid and the vehicle.
 Trigger Conditions
 ==================
 
- IEC 61851-23, sections FF.5.6
+- IEC 61851-23, sections FF.5.6
 
 Related Telemetry
 =================

--- a/specification/error_codes/definitions_ContactorPosition.rst
+++ b/specification/error_codes/definitions_ContactorPosition.rst
@@ -1,0 +1,33 @@
+..
+   SPDX-License-Identifier: CC-BY-4.0
+   Copyright CharIN e.V. and Contributors
+
+#############
+ Error Codes
+#############
+
+This section defines the error codes.
+
+.. _error_ContactorPosition:
+
+**************
+ ContactorPosition
+**************
+
+Description
+===========
+
+A contactor fault occurs when an electromechanical contactor in either the EV or the EVSE fails to switch to its commanded state or leaves that state unintentionally. In high-voltage (HV) charging systems, this fault represents a malfunction in the contactors responsible for safely connecting or disconnecting HV power within the vehicle’s powertrain or 
+within the EVSE that manages power flow between the grid and the vehicle.
+
+Trigger Conditions
+==================
+
+ IEC 61851-23, sections FF.5.6
+
+Related Telemetry
+=================
+
+The following telemetry signals are required for analyzing this error:
+
+

--- a/specification/error_codes/definitions_ContactorPosition.rst
+++ b/specification/error_codes/definitions_ContactorPosition.rst
@@ -10,9 +10,9 @@ This section defines the error codes.
 
 .. _error_ContactorPosition:
 
-**************
+******************
  ContactorPosition
-**************
+******************
 
 Description
 ===========
@@ -29,5 +29,6 @@ Related Telemetry
 =================
 
 The following telemetry signals are required for analyzing this error:
+TBD
 
 

--- a/specification/error_codes/definitions_EVShiftPosition.rst
+++ b/specification/error_codes/definitions_EVShiftPosition.rst
@@ -2,13 +2,7 @@
    SPDX-License-Identifier: CC-BY-4.0
    Copyright CharIN e.V. and Contributors
 
-#############
- Error Codes
-#############
-
-This section defines the error codes.
-
-.. _error_EVShiftPosition:
+.. _error_evshiftposition:
 
 ****************
  EVShiftPosition
@@ -23,8 +17,8 @@ not in Park, or otherwise not conducive to charging.
 Trigger Conditions
 ==================
 
-The Shift Position is Unknown.
-The Shift Position is not in park during Power Delivery.
+- The Shift Position is Unknown.
+- The Shift Position is not in Park during Power Delivery.
 
 Related Telemetry
 =================

--- a/specification/error_codes/definitions_EVShiftPosition.rst
+++ b/specification/error_codes/definitions_EVShiftPosition.rst
@@ -10,9 +10,9 @@ This section defines the error codes.
 
 .. _error_EVShiftPosition:
 
-**************
+****************
  EVShiftPosition
-**************
+****************
 
 Description
 ===========
@@ -30,5 +30,6 @@ Related Telemetry
 =================
 
 The following telemetry signals are required for analyzing this error:
+TBD
 
 

--- a/specification/error_codes/definitions_EVShiftPosition.rst
+++ b/specification/error_codes/definitions_EVShiftPosition.rst
@@ -1,0 +1,34 @@
+..
+   SPDX-License-Identifier: CC-BY-4.0
+   Copyright CharIN e.V. and Contributors
+
+#############
+ Error Codes
+#############
+
+This section defines the error codes.
+
+.. _error_EVShiftPosition:
+
+**************
+ EVShiftPosition
+**************
+
+Description
+===========
+
+Vehicle shift position is not appropriate for charging because the current gear state is unknown, 
+not in Park, or otherwise not conducive to charging.
+
+Trigger Conditions
+==================
+
+The Shift Position is Unknown.
+The Shift Position is not in park during Power Delivery.
+
+Related Telemetry
+=================
+
+The following telemetry signals are required for analyzing this error:
+
+

--- a/specification/index.rst
+++ b/specification/index.rst
@@ -14,4 +14,6 @@ for electric vehicle charging stations.
    :caption: Contents:
 
    error_codes/definitions
+   error_codes/definitions_EVShiftPosition
+   error_codes/definitions_ContactorPosition
    telemetry/definitions


### PR DESCRIPTION
Separated the Definitions Files for Contactor Position and EV shift Position into their own .rst  - and index.rst.  I think the individual .rst based on definitions is the correct path forward. 

https://github.com/charinev/unified-error-codes/issues/23
https://github.com/charinev/unified-error-codes/issues/10