### PR TITLE
Add PowerModuleFault error code definition

### DIFF
--- a/specification/conf.py
+++ b/specification/conf.py
@@ -16,7 +16,7 @@ author = 'CharIN e.V. and Contributors'
 extensions = []
 
 templates_path = ['_templates']
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', '**/definitions_*.rst']
 
 
 

--- a/specification/error_codes/definitions.rst
+++ b/specification/error_codes/definitions.rst
@@ -40,3 +40,4 @@ The following telemetry signals are required for analyzing this error:
 .. include:: definitions_ContactorPosition.rst
 .. include:: definitions_ConnectorLockFailure.rst
 .. include:: definitions_HighTemperature.rst
+.. include:: definitions_PowerModuleFault.rst

--- a/specification/error_codes/definitions_PowerModuleFault.rst
+++ b/specification/error_codes/definitions_PowerModuleFault.rst
@@ -1,0 +1,43 @@
+..
+   SPDX-License-Identifier: CC-BY-4.0
+   Copyright CharIN e.V. and Contributors
+
+.. _error_powermodulefault:
+
+******************
+ PowerModuleFault
+******************
+
+Description
+===========
+
+A power conversion fault occurs when any power module or converter channel
+within the EVSE or EV — such as AC/DC, DC/DC, or DC/AC — fails to deliver the
+commanded power. In the EVSE, this usually involves faults in the power modules
+that rectify or invert energy for delivery to the vehicle, while in the EV it
+includes failures in on-board converters that manage energyflow to or from the
+battery.
+
+This error code is applicable to and can be set by either the EV or EVSE,
+depending on which side owns the affected power module or converter.
+
+Trigger Conditions
+==================
+
+-  A power module or converter reports a fault, whose module-specific error code
+   is passed through as the root cause.
+-  Internal diagnostics of the power module or converter report a protection
+   trip (for example, overvoltage protection) as described by IEC 61851-23,
+   sections AA.3.12 and BB.5.6.
+
+Related Telemetry
+=================
+
+The following telemetry signals are required for analyzing this error:
+
+-  :ref:`telemetry_power_module_identifier`
+-  :ref:`telemetry_power_module_location`
+-  :ref:`telemetry_power_module_specific_error_code`
+-  :ref:`telemetry_power_module_vendor`
+-  :ref:`telemetry_power_module_model`
+-  :ref:`telemetry_power_module_firmware_version`

--- a/specification/telemetry/definitions.rst
+++ b/specification/telemetry/definitions.rst
@@ -74,3 +74,4 @@ the charging station.
 
 .. include:: definitions_ConnectorLockTelemetry.rst
 .. include:: definitions_HighTemperatureTelemetry.rst
+.. include:: definitions_PowerModuleTelemetry.rst

--- a/specification/telemetry/definitions_PowerModuleTelemetry.rst
+++ b/specification/telemetry/definitions_PowerModuleTelemetry.rst
@@ -1,0 +1,63 @@
+..
+   SPDX-License-Identifier: CC-BY-4.0
+   Copyright CharIN e.V. and Contributors
+
+.. _telemetry_power_module_identifier:
+
+************************
+ Power Module Identifier
+************************
+
+-  **Description**: The identifier of the power module or converter channel that raised
+   the fault. Distinguishes the affected module when multiple modules are
+   present in the EVSE or EV.
+
+.. _telemetry_power_module_location:
+
+**********************
+ Power Module Location
+**********************
+
+-  **Description**: The physical location of the power module or converter channel within
+   the EVSE or EV. Used together with the identifier to locate the affected
+   module for diagnostics and service.
+
+.. _telemetry_power_module_specific_error_code:
+
+*********************************
+ Power Module Specific Error Code
+*********************************
+
+-  **Description**: The error code reported by the power module itself, forwarded up
+   through the specification to convey the root cause. On the EVSE this is the
+   vendor-specific error code; on the EV this is typically the inverter error
+   code or Diagnostic Trouble Code (DTC) that was set. Decoding may require the
+   module vendor, model, and
+   firmware version.
+
+.. _telemetry_power_module_vendor:
+
+********************
+ Power Module Vendor
+********************
+
+-  **Description**: The vendor of the power module or converter channel. Aids decoding of
+   the vendor-specific error code.
+
+.. _telemetry_power_module_model:
+
+*******************
+ Power Module Model
+*******************
+
+-  **Description**: The model of the power module or converter channel.
+
+.. _telemetry_power_module_firmware_version:
+
+******************************
+ Power Module Firmware Version
+******************************
+
+-  **Description**: The firmware version of the power module or converter channel. Aids
+   decoding of the vendor-specific error code and correlating known
+   firmware-related faults.


### PR DESCRIPTION
Adds the PowerModuleFault error code covering power conversion faults in EVSE and EV power modules and converters (AC/DC, DC/DC, DC/AC), along with its six related power-module telemetry signals.

The new definitions are wired into the existing include-based layout, and include-only partials are excluded from standalone parsing so cross-references resolve correctly and duplicate-label build warnings are cleared.

Closes #9