### PR TITLE
Fix PDF structure for error codes sections

### DIFF
--- a/specification/error_codes/definitions.rst
+++ b/specification/error_codes/definitions.rst
@@ -35,3 +35,6 @@ The following telemetry signals are required for analyzing this error:
 -  :ref:`telemetry_supply_voltage_l1`
 -  :ref:`telemetry_supply_voltage_l2`
 -  :ref:`telemetry_supply_voltage_l3`
+
+.. include:: definitions_EVShiftPosition.rst
+.. include:: definitions_ContactorPosition.rst

--- a/specification/index.rst
+++ b/specification/index.rst
@@ -14,6 +14,4 @@ for electric vehicle charging stations.
    :caption: Contents:
 
    error_codes/definitions
-   error_codes/definitions_EVShiftPosition
-   error_codes/definitions_ContactorPosition
    telemetry/definitions


### PR DESCRIPTION
The sections were structured incorrectly.
As a consequence, every error code definition was a separate chapter in the document.

This change fixes that problem.