### PR TITLE
Add GitHub Pages workflow for automated documentation deployment

### DIFF
--- a/.github/workflows/build-specification-pdf.yml
+++ b/.github/workflows/build-specification-pdf.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build PDF using Sphinx and LaTeX
         uses: docker://sphinxdoc/sphinx-latexpdf:8.2.3
@@ -22,7 +22,7 @@ jobs:
           args: make -C specification latexpdf
 
       - name: Upload PDF as Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Specification PDF
           path: specification/_build/latex/*.pdf

--- a/.github/workflows/deploy-specification-pages.yml
+++ b/.github/workflows/deploy-specification-pages.yml
@@ -1,0 +1,32 @@
+name: Deploy Specification HTML to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy-specification-pages:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Build HTML using Sphinx
+        uses: docker://sphinxdoc/sphinx-latexpdf:8.2.3
+        with:
+          args: make -C specification html
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: specification/_build/html
+
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
This PR introduces a GitHub Actions workflow to automatically deploy our project documentation to GitHub Pages whenever changes are pushed to the main branch.