### PR TITLE
Add LowTemperature error code and shared temperature telemetry

### DIFF
--- a/specification/error_codes/definitions_HighTemperature.rst
+++ b/specification/error_codes/definitions_HighTemperature.rst
@@ -43,6 +43,6 @@ Related Telemetry
 
 The following telemetry signals are required for analyzing this error:
 
--  :ref:`telemetry_hightemperature_actual`
--  :ref:`telemetry_hightemperature_threshold`
--  :ref:`telemetry_hightemperature_location`
+-  :ref:`telemetry_temperature_actual`
+-  :ref:`telemetry_temperature_threshold`
+-  :ref:`telemetry_temperature_location`

--- a/specification/error_codes/definitions_LowTemperature.rst
+++ b/specification/error_codes/definitions_LowTemperature.rst
@@ -1,0 +1,34 @@
+..
+   SPDX-License-Identifier: CC-BY-4.0
+   Copyright CharIN e.V. and Contributors
+
+.. _error_lowtemperature:
+
+*****************
+ Low Temperature
+*****************
+
+Description
+===========
+
+The temperature of an EVSE or EV high-voltage component has fallen below the
+minimum operating threshold required for safe charging. The error is reported
+against the subsystem (Location) that observed the under-temperature
+condition. This condition will typically result in a derated (reduced-power)
+charging capability rather than a complete shutdown until the temperature
+returns within the allowable range.
+
+Trigger Conditions
+==================
+
+- Measured temperature at the reporting Location drops below the minimum
+  operating threshold defined by the manufacturer.
+
+Related Telemetry
+=================
+
+The following telemetry signals are required for analyzing this error:
+
+-  :ref:`telemetry_temperature_actual`
+-  :ref:`telemetry_temperature_threshold`
+-  :ref:`telemetry_temperature_location`

--- a/specification/index.rst
+++ b/specification/index.rst
@@ -17,4 +17,5 @@ for electric vehicle charging stations.
    error_codes/definitions_EVShiftPosition
    error_codes/definitions_ContactorPosition
    error_codes/definitions_Overvoltage
+   error_codes/definitions_LowTemperature
    telemetry/definitions

--- a/specification/telemetry/definitions.rst
+++ b/specification/telemetry/definitions.rst
@@ -73,5 +73,5 @@ the charging station.
    -  ``SessionStop`` — Error occurred during SessionStop.
 
 .. include:: definitions_ConnectorLockTelemetry.rst
-.. include:: definitions_HighTemperatureTelemetry.rst
+.. include:: definitions_TemperatureTelemetry.rst
 .. include:: definitions_PowerModuleTelemetry.rst

--- a/specification/telemetry/definitions_TemperatureTelemetry.rst
+++ b/specification/telemetry/definitions_TemperatureTelemetry.rst
@@ -2,30 +2,33 @@
    SPDX-License-Identifier: CC-BY-4.0
    Copyright CharIN e.V. and Contributors
 
-.. _telemetry_hightemperature_actual:
+.. _telemetry_temperature_actual:
 
-***********************
+********************
  Actual Temperature
-***********************
+********************
 
 -  **Description**: The measured temperature of the EVSE or EV component
-   reported as the source of the overtemperature condition.
+   reported as the source of the temperature fault.
 -  **Unit**: Degrees Celsius (°C)
 -  **Resolution**: `1 °C`
 
-.. _telemetry_hightemperature_threshold:
+.. _telemetry_temperature_threshold:
 
-*******************************
- Calibration Threshold
-*******************************
+***********************
+ Temperature Threshold
+***********************
 
--  **Description**: The calibrated safety or performance temperature threshold
-   for the reporting component, above which the overtemperature fault is
-   raised, as defined by the applicable standard or the manufacturer.
+-  **Description**: The calibrated safety or performance temperature
+   threshold for the reporting component, defined by the applicable standard
+   or the manufacturer. For an overtemperature fault this is the maximum
+   temperature above which the fault is raised; for an under-temperature
+   fault this is the minimum operating temperature below which the fault is
+   raised.
 -  **Unit**: Degrees Celsius (°C)
 -  **Resolution**: `1 °C`
 
-.. _telemetry_hightemperature_location:
+.. _telemetry_temperature_location:
 
 **********************
  Temperature Location


### PR DESCRIPTION
Introduces the LowTemperature error code, covering the under-temperature condition where an EVSE or EV high-voltage component drops below its minimum operating threshold — typically resulting in derated charging rather than a full shutdown, until the temperature returns to the allowable range.

Since this condition mirrors the existing HighTemperature (overtemperature) error code, the two now share a single set of temperature telemetry signals (actual temperature, threshold, and location) instead of maintaining separate, near-duplicate definitions. The threshold description was generalized to cover both the upper bound used by HighTemperature and the lower bound used by LowTemperature, and HighTemperature's telemetry references were repointed to the shared signals. The specification's error code toctree and telemetry chapter were updated accordingly.

Closes: #12