### PR TITLE
Add HighTemperature error code and telemetry

### DIFF
--- a/specification/error_codes/definitions.rst
+++ b/specification/error_codes/definitions.rst
@@ -39,3 +39,4 @@ The following telemetry signals are required for analyzing this error:
 .. include:: definitions_EVShiftPosition.rst
 .. include:: definitions_ContactorPosition.rst
 .. include:: definitions_ConnectorLockFailure.rst
+.. include:: definitions_HighTemperature.rst

--- a/specification/error_codes/definitions_HighTemperature.rst
+++ b/specification/error_codes/definitions_HighTemperature.rst
@@ -1,0 +1,48 @@
+..
+   SPDX-License-Identifier: CC-BY-4.0
+   Copyright CharIN e.V. and Contributors
+
+.. _error_hightemperature:
+
+******************
+ High Temperature
+******************
+
+Description
+===========
+
+An overtemperature fault occurs when the measured temperature of a system or
+component within the EV or EVSE exceeds its calibrated safety or performance
+threshold during charging. The fault is reported against the subsystem
+(Location) that observed the overtemperature condition.
+
+This error code is applicable to and can be set by either the EV or EVSE,
+depending on which side owns the affected component and its thermal
+monitoring. This allows the same definition and criteria to be used for both
+EV and EVSE.
+
+Trigger Conditions
+==================
+
+- Measured temperature at the reporting Location exceeds the calibrated safety
+  or performance threshold defined by the applicable standard or manufacturer.
+
+Criteria
+========
+
+Reference criteria from IEC 61851-23:
+
+-  101.2.2.1 — Temperature of the DC contact assembly of the vehicle
+   connector.
+-  101.2.3.2 — Overtemperature handling.
+-  101.2.3.3 — Check of the plausibility of the values provided by the thermal
+   sensing devices.
+
+Related Telemetry
+=================
+
+The following telemetry signals are required for analyzing this error:
+
+-  :ref:`telemetry_hightemperature_actual`
+-  :ref:`telemetry_hightemperature_threshold`
+-  :ref:`telemetry_hightemperature_location`

--- a/specification/telemetry/definitions.rst
+++ b/specification/telemetry/definitions.rst
@@ -73,3 +73,4 @@ the charging station.
    -  ``SessionStop`` — Error occurred during SessionStop.
 
 .. include:: definitions_ConnectorLockTelemetry.rst
+.. include:: definitions_HighTemperatureTelemetry.rst

--- a/specification/telemetry/definitions_HighTemperatureTelemetry.rst
+++ b/specification/telemetry/definitions_HighTemperatureTelemetry.rst
@@ -1,0 +1,52 @@
+..
+   SPDX-License-Identifier: CC-BY-4.0
+   Copyright CharIN e.V. and Contributors
+
+.. _telemetry_hightemperature_actual:
+
+***********************
+ Actual Temperature
+***********************
+
+-  **Description**: The measured temperature of the EVSE or EV component
+   reported as the source of the overtemperature condition.
+-  **Unit**: Degrees Celsius (°C)
+-  **Resolution**: `1 °C`
+
+.. _telemetry_hightemperature_threshold:
+
+*******************************
+ Calibration Threshold
+*******************************
+
+-  **Description**: The calibrated safety or performance temperature threshold
+   for the reporting component, above which the overtemperature fault is
+   raised, as defined by the applicable standard or the manufacturer.
+-  **Unit**: Degrees Celsius (°C)
+-  **Resolution**: `1 °C`
+
+.. _telemetry_hightemperature_location:
+
+**********************
+ Temperature Location
+**********************
+
+-  **Description**: The subsystem or device component against which the
+   temperature is reported.
+-  **Values**:
+
+   -  ``Cable`` — Charging cable.
+   -  ``CablePositive`` — Charging cable positive line.
+   -  ``CableNegative`` — Charging cable negative line.
+   -  ``CableHousingPositive`` — Cable housing positive line.
+   -  ``CableHousingNegative`` — Cable housing negative line.
+   -  ``ConnectorPositive`` — Connector/Plug positive pin.
+   -  ``ConnectorNegative`` — Connector/Plug negative pin.
+   -  ``PowerModulesSideA`` — Power modules Side A.
+   -  ``PowerModulesSideB`` — Power modules Side B.
+   -  ``Electronics`` — Electronic/control components.
+   -  ``Socket`` — Charging socket.
+   -  ``SocketPositive`` — Charging socket positive pin.
+   -  ``SocketNegative`` — Charging socket negative pin.
+   -  ``Battery`` — EV Battery.
+   -  ``Body`` — EVSE/EV body.


### PR DESCRIPTION
Adds the **HighTemperature** hardware error code and its related telemetry.

Changes:
- `definitions_HighTemperature.rst` — error-code definition (description, trigger conditions, IEC 61851-23 criteria).
- `definitions_HighTemperatureTelemetry.rst` — telemetry signals: Actual Temperature, Threshold, Temperature Measurement Location.
- Wired both files into the respective `definitions.rst` includes.

Closes #11