### PR TITLE
Add UnderCurrent error code and telemetry

### DIFF
--- a/specification/error_codes/definitions.rst
+++ b/specification/error_codes/definitions.rst
@@ -41,3 +41,4 @@ The following telemetry signals are required for analyzing this error:
 .. include:: definitions_ConnectorLockFailure.rst
 .. include:: definitions_HighTemperature.rst
 .. include:: definitions_PowerModuleFault.rst
+.. include:: definitions_UnderCurrent.rst

--- a/specification/error_codes/definitions_UnderCurrent.rst
+++ b/specification/error_codes/definitions_UnderCurrent.rst
@@ -1,0 +1,42 @@
+..
+   SPDX-License-Identifier: CC-BY-4.0
+   Copyright CharIN e.V. and Contributors
+
+.. _error_undercurrent:
+
+**************
+ UnderCurrent
+**************
+
+Description
+===========
+
+This error is raised by the EVSE when the current it delivers to the EV
+falls below the current it has committed to supply for the active
+charging schedule.
+
+Out of Scope
+============
+
+-  An EV drawing less current than the EVSE offers, which is normal
+   behavior in unidirectional charging.
+-  EV deviations from its committed power profile under ISO 15118-20
+   power tolerance.
+-  Bi-directional charging (V2G/V2H) under-current conditions.
+
+Trigger Conditions
+==================
+
+-  The measured output current at the supply or transmission interface
+   falls below the current level committed for the active schedule, for
+   longer than a defined qualification time, as specified by the
+   applicable standard or the manufacturer-defined schedule commitment.
+
+Related Telemetry
+=================
+
+The following telemetry signals are required for analyzing this error:
+
+-  :ref:`telemetry_undercurrent_location`
+-  :ref:`telemetry_undercurrent_expected`
+-  :ref:`telemetry_undercurrent_actual`

--- a/specification/telemetry/definitions.rst
+++ b/specification/telemetry/definitions.rst
@@ -75,3 +75,4 @@ the charging station.
 .. include:: definitions_ConnectorLockTelemetry.rst
 .. include:: definitions_HighTemperatureTelemetry.rst
 .. include:: definitions_PowerModuleTelemetry.rst
+.. include:: definitions_UnderCurrentTelemetry.rst

--- a/specification/telemetry/definitions_UnderCurrentTelemetry.rst
+++ b/specification/telemetry/definitions_UnderCurrentTelemetry.rst
@@ -1,0 +1,38 @@
+..
+   SPDX-License-Identifier: CC-BY-4.0
+   Copyright CharIN e.V. and Contributors
+
+.. _telemetry_undercurrent_location:
+
+************************
+ UnderCurrent Location
+************************
+
+-  **Description**: The location at which the under-current condition
+   was measured.
+-  **Values**:
+
+   -  ``Supply`` — EVSE input / Site A.
+   -  ``Transmission`` — EVSE-to-EV path / Site B.
+
+.. _telemetry_undercurrent_expected:
+
+***************************
+ Expected Current Output
+***************************
+
+-  **Description**: The current committed for the active charging
+   schedule at the reported location.
+-  **Unit**: Amperes (A)
+-  **Resolution**: `0.1 A`
+
+.. _telemetry_undercurrent_actual:
+
+*************************
+ Actual Current Output
+*************************
+
+-  **Description**: The current measured at the reported location at
+   the time of the under-current condition.
+-  **Unit**: Amperes (A)
+-  **Resolution**: `0.1 A`


### PR DESCRIPTION
Adds an EVSE-scoped `UnderCurrent` error-code definition, raised when the EVSE's delivered current falls below what it committed to supply for the active charging schedule.

Adds the three related telemetry signals (`UnderCurrent Location`, `Expected Current Output`, `Actual Current Output`), wired into `telemetry/definitions.rst`.