### PR TITLE
Include Overvoltage and OverCurrent in the built specification

### DIFF
--- a/specification/error_codes/definitions.rst
+++ b/specification/error_codes/definitions.rst
@@ -41,3 +41,5 @@ The following telemetry signals are required for analyzing this error:
 .. include:: definitions_ConnectorLockFailure.rst
 .. include:: definitions_HighTemperature.rst
 .. include:: definitions_PowerModuleFault.rst
+.. include:: definitions_Overvoltage.rst
+.. include:: definitions_OverCurrent.rst

--- a/specification/error_codes/definitions_OverCurrent.rst
+++ b/specification/error_codes/definitions_OverCurrent.rst
@@ -2,11 +2,11 @@
    SPDX-License-Identifier: CC-BY-4.0
    Copyright CharIN e.V. and Contributors
 
-_error_sideb_overcurrent:
+.. _error_sideb_overcurrent:
 
-**********************
+**************************
  SideB_OverCurrentFailure
-**********************
+**************************
 
 Description
 ===========

--- a/specification/index.rst
+++ b/specification/index.rst
@@ -14,7 +14,4 @@ for electric vehicle charging stations.
    :caption: Contents:
 
    error_codes/definitions
-   error_codes/definitions_EVShiftPosition
-   error_codes/definitions_ContactorPosition
-   error_codes/definitions_Overvoltage
    telemetry/definitions

--- a/specification/telemetry/definitions.rst
+++ b/specification/telemetry/definitions.rst
@@ -75,3 +75,4 @@ the charging station.
 .. include:: definitions_ConnectorLockTelemetry.rst
 .. include:: definitions_HighTemperatureTelemetry.rst
 .. include:: definitions_PowerModuleTelemetry.rst
+.. include:: definitions_OverCurrentTelemetry.rst


### PR DESCRIPTION
Two of the eight error codes in the 0.1.0 scope never reached the built document. Overvoltage and OverCurrent were only reachable through toctree entries in index.rst, which conf.py excludes via the definitions_*.rst pattern, and neither had an include directive in error_codes/definitions.rst. The OverCurrent label was also missing its leading two dots so it was not a reference target, and its title overline was shorter than the title. The three dead toctree entries are dropped as well.

Worth knowing before merging: rendering Overvoltage for the first time also surfaces about 24 docutils warnings from the raw JSON block in its Related Telemetry section. Those were always latent, they just were not built. #75 fixes them, so merging that one soon after this keeps the build tidy.

Closes #74