### PR TITLE
Normalize error code names

### DIFF
--- a/specification/error_codes/definitions.rst
+++ b/specification/error_codes/definitions.rst
@@ -8,6 +8,12 @@
 
 This section defines the error codes.
 
+Error codes are identified by name rather than by number, so that they stay
+stable as the catalogue grows. Names are written in UpperCamelCase, without
+spaces or separators. Where a condition was observed is carried by telemetry
+rather than by the name, so that one name covers the condition wherever it
+occurs.
+
 .. _error_gridpowerloss:
 
 **************

--- a/specification/error_codes/definitions_HighTemperature.rst
+++ b/specification/error_codes/definitions_HighTemperature.rst
@@ -4,9 +4,9 @@
 
 .. _error_hightemperature:
 
-******************
- High Temperature
-******************
+*****************
+ HighTemperature
+*****************
 
 Description
 ===========

--- a/specification/error_codes/definitions_OverCurrent.rst
+++ b/specification/error_codes/definitions_OverCurrent.rst
@@ -2,11 +2,11 @@
    SPDX-License-Identifier: CC-BY-4.0
    Copyright CharIN e.V. and Contributors
 
-_error_sideb_overcurrent:
+.. _error_overcurrent:
 
-**********************
- SideB_OverCurrentFailure
-**********************
+*************
+ OverCurrent
+*************
 
 Description
 ===========
@@ -29,7 +29,7 @@ Related Telemetry
 
 The following telemetry signals are required for analyzing this error:
 
--  :ref:`Telemetry_SideB_OverCurrent_Location`
--  :ref:`Telemetry_SideB_OverCurrent_ActualCurrent`
--  :ref:`Telemetry_SideB_OverCurrent_ThresholdCurrent`
+-  :ref:`Telemetry_OverCurrent_Location`
+-  :ref:`Telemetry_OverCurrent_ActualCurrent`
+-  :ref:`Telemetry_OverCurrent_ThresholdCurrent`
 

--- a/specification/telemetry/definitions_OverCurrentTelemetry.rst
+++ b/specification/telemetry/definitions_OverCurrentTelemetry.rst
@@ -2,7 +2,7 @@
    SPDX-License-Identifier: CC-BY-4.0
    Copyright CharIN e.V. and Contributors
 
-.. _Telemetry_SideB_OverCurrent_Location:
+.. _Telemetry_OverCurrent_Location:
 
 ************************
  OverCurrent Location
@@ -12,7 +12,7 @@
 -  **Unit**: N/A
 -  **Resolution**: N/A
 
-.. _Telemetry_SideB_OverCurrent_ActualCurrent:
+.. _Telemetry_OverCurrent_ActualCurrent:
 
 ***********************
  Actual Current
@@ -23,7 +23,7 @@
 -  **Unit**: Amperes (A)
 -  **Resolution**: 0.1 A
 
-.. _Telemetry_SideB_OverCurrent_ThresholdCurrent:
+.. _Telemetry_OverCurrent_ThresholdCurrent:
 
 ***********************
  Threshold Current


### PR DESCRIPTION
States the naming convention in the Error Codes section — names, not numbers, UpperCamelCase, and where a condition was observed carried by telemetry rather than by the name — and applies it to the two names that did not follow it.

High Temperature becomes HighTemperature, so every title is one word like the rest of the catalogue. SideB_OverCurrentFailure becomes OverCurrent: it carried the only underscore and the only side prefix in the catalogue, and which side the over current occurred on already travels in the OverCurrent Location telemetry signal, whose labels are renamed to match. Overvoltage handles Site A and Site B the same way inside a single code.

That second rename is the one worth a look — it is a proposal, not a cleanup, and easy to reverse if the group prefers the side in the name.

Both OCPP mapping tables are keyed on these names, so settling them now avoids churning those tables later.

Closes #76