### PR TITLE
Add Scope and Conventions clauses, make telemetry an informative annex

### DIFF
--- a/specification/conventions/definitions.rst
+++ b/specification/conventions/definitions.rst
@@ -1,0 +1,30 @@
+..
+   SPDX-License-Identifier: CC-BY-4.0
+   Copyright CharIN e.V. and Contributors
+
+#############
+ Conventions
+#############
+
+Normative language
+==================
+
+In the normative clauses of this document:
+
+-  **shall** indicates a requirement: something that has to be done to conform
+   to this document.
+-  **shall not** indicates a prohibition.
+-  **should** indicates a recommendation: one course of action is preferred,
+   without others being excluded.
+-  **should not** indicates that a course of action is deprecated but not
+   prohibited.
+-  **may** indicates a permission.
+-  **can** indicates a possibility or a capability, and states a fact rather
+   than a requirement.
+
+These terms carry this meaning only in the normative clauses. Elsewhere, and
+throughout Annex A, they are ordinary English.
+
+Where this document quotes a field name, a message name or an enumeration value
+from another specification, it is written in ``monospace`` and spelled exactly
+as that specification spells it.

--- a/specification/index.rst
+++ b/specification/index.rst
@@ -6,15 +6,14 @@
  Unified Error Codes
 #####################
 
-This document specifies a unified set of error codes and telemetry signals
-for electric vehicle charging stations.
+This document specifies a unified set of error codes for electric vehicle
+charging, and how an EVSE delivers them to a charging management system.
 
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
 
+   scope/definitions
+   conventions/definitions
    error_codes/definitions
-   error_codes/definitions_EVShiftPosition
-   error_codes/definitions_ContactorPosition
-   error_codes/definitions_Overvoltage
    telemetry/definitions

--- a/specification/scope/definitions.rst
+++ b/specification/scope/definitions.rst
@@ -1,0 +1,43 @@
+..
+   SPDX-License-Identifier: CC-BY-4.0
+   Copyright CharIN e.V. and Contributors
+
+#######
+ Scope
+#######
+
+This document specifies a unified set of error codes for electric vehicle
+charging, and how an EVSE delivers them to a charging management system.
+
+An error code identifies a condition that an EV or an EVSE has detected, by a
+name that both sides and the charging management system understand the same
+way. The purpose is diagnostic: a charge point operator, a vehicle manufacturer
+and an EVSE manufacturer looking at the same failed charging session should be
+able to name its cause identically without a bilateral agreement between them.
+
+Normative and informative parts
+===============================
+
+The following clauses are normative:
+
+-  :doc:`Scope <../scope/definitions>`
+-  :doc:`Conventions <../conventions/definitions>`
+-  :doc:`Error Codes <../error_codes/definitions>`
+-  The clauses specifying delivery of error codes to a charging management
+   system.
+
+:doc:`Annex A <../telemetry/definitions>` is informative. It is published for
+early feedback and states no requirements. Where an error code lists the
+telemetry related to it, that list is a pointer into Annex A and is likewise
+informative.
+
+Out of scope in this edition
+============================
+
+-  Delivery of telemetry to a charging management system. The telemetry signals
+   in Annex A are given so that the error codes can be discussed with the
+   measurements that make them diagnosable, but how those measurements travel
+   over OCPP is not settled and is therefore not specified here.
+-  Exchange of error codes between the EV and the EVSE.
+-  Severity classification of error codes.
+-  Reporting several error codes as a single correlated group.

--- a/specification/telemetry/definitions.rst
+++ b/specification/telemetry/definitions.rst
@@ -2,12 +2,19 @@
    SPDX-License-Identifier: CC-BY-4.0
    Copyright CharIN e.V. and Contributors
 
-###########
- Telemetry
-###########
+###########################################
+ Annex A (informative) — Telemetry Signals
+###########################################
 
-This section defines the telemetry signals that shall be monitored by
-the charging station.
+This annex is informative. It states no requirements, and nothing in it is
+needed to conform to this document.
+
+It lists the telemetry signals that make each error code diagnosable, and each
+error code refers to the signals relevant to it. The signals are published
+here for early feedback while the group settles how telemetry should be
+delivered to a charging management system; until that is settled, specifying
+the signals normatively would fix a data model to a delivery mechanism that
+does not yet exist.
 
 .. _telemetry_supply_voltage_l1:
 


### PR DESCRIPTION
Release 0.1.0 covers error codes only, because we have not decided how telemetry should be delivered over OCPP. Rather than removing the telemetry definitions from the document, this marks them as Annex A, informative, published for early feedback and stating no requirements. Promoting them to normative later is then a clause move rather than a revert, and nothing is lost in the meantime.

It also adds the two clauses the OCPP delivery chapters need to exist first: a Scope clause saying what the document specifies, which parts are normative, and what is out of scope in this edition; and a Conventions clause defining shall, should, may and can, so those chapters can state requirements without inventing the meaning as they go. DIN DKE SPEC 99003 has neither, which is why its requirements are hard to read as requirements.

The three toctree entries pointing at documents conf.py excludes are dropped here too, which overlaps with #74 — same resolution either way.

Document now builds with one warning, the pre-existing missing _static directory.

Closes #77
Closes #73