### PR TITLE
Specify error code delivery over OCPP 1.6

### DIFF
--- a/specification/index.rst
+++ b/specification/index.rst
@@ -17,4 +17,5 @@ for electric vehicle charging stations.
    error_codes/definitions_EVShiftPosition
    error_codes/definitions_ContactorPosition
    error_codes/definitions_Overvoltage
+   ocpp16/definitions
    telemetry/definitions

--- a/specification/ocpp16/definitions.rst
+++ b/specification/ocpp16/definitions.rst
@@ -1,0 +1,17 @@
+..
+   SPDX-License-Identifier: CC-BY-4.0
+   Copyright CharIN e.V. and Contributors
+
+####################################
+ Error Code Delivery over OCPP 1.6
+####################################
+
+This section specifies how an EVSE reports an error code defined in
+:doc:`../error_codes/definitions` to a charging management system using
+`OCPP 1.6 <https://openchargealliance.org/protocols/open-charge-point-protocol/>`_.
+
+It specifies delivery of the error code only. Telemetry is not carried over
+OCPP 1.6 by this edition.
+
+.. include:: definitions_ErrorCodeDelivery16.rst
+.. include:: definitions_ErrorCodeMapping16.rst

--- a/specification/ocpp16/definitions_ErrorCodeDelivery16.rst
+++ b/specification/ocpp16/definitions_ErrorCodeDelivery16.rst
@@ -9,7 +9,7 @@
 *******************************
 
 Message
-=======
+=========
 
 An error code is reported in a ``StatusNotification.req`` message.
 
@@ -94,7 +94,7 @@ cause. Reporting several error codes as a correlated group is out of scope in
 this edition.
 
 Example
-=======
+=========
 
 A contactor that failed to reach its commanded state, reported against
 connector 1:

--- a/specification/ocpp16/definitions_ErrorCodeDelivery16.rst
+++ b/specification/ocpp16/definitions_ErrorCodeDelivery16.rst
@@ -1,0 +1,122 @@
+..
+   SPDX-License-Identifier: CC-BY-4.0
+   Copyright CharIN e.V. and Contributors
+
+.. _ocpp16_error_code_delivery:
+
+*******************************
+ Reporting an Error Code
+*******************************
+
+Message
+=======
+
+An error code is reported in a ``StatusNotification.req`` message.
+
+OCPP 1.6 caps ``info`` and ``vendorErrorCode`` at 50 characters each, which is
+why DIN DKE SPEC 99003 pairs every ``StatusNotification.req`` with a
+``DataTransfer.req`` carrying the detail that does not fit. An error code name
+fits, so this edition needs no second message. ``DataTransfer.req`` is left
+unused and available to a future edition that carries telemetry.
+
+Field usage
+===========
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 20 58
+
+   -  -  Field
+      -  Value
+      -  Description
+
+   -  -  ``connectorId``
+      -  integer
+      -  Required. The connector the condition was detected on, or ``0`` when
+         the condition belongs to the charging station as a whole rather than
+         to one connector. OCPP 1.6 admits only ``Available``, ``Unavailable``
+         and ``Faulted`` as the status of connector ``0``.
+
+   -  -  ``errorCode``
+      -  ``ChargePointErrorCode``
+      -  Required by OCPP 1.6, whose enumeration is closed and cannot carry an
+         error code name. It shall be set to the value that
+         :ref:`ocpp16_error_code_mapping` gives for the reported error code.
+
+   -  -  ``status``
+      -  ``ChargePointStatus``
+      -  Required. ``Faulted`` when the condition prevents energy delivery. Any
+         other status means, in OCPP 1.6, that charging operations remain
+         possible and the condition is a warning.
+
+   -  -  ``timestamp``
+      -  dateTime
+      -  Optional in OCPP 1.6; required by this document. The time the
+         condition was detected, in UTC.
+
+   -  -  ``vendorId``
+      -  ``CiString255Type``
+      -  Required. Shall be ``org.charin.uec.v1``, which identifies
+         ``vendorErrorCode`` as an error code name from this document. OCPP 1.6
+         recommends a reversed DNS name for this field.
+
+   -  -  ``vendorErrorCode``
+      -  ``CiString50Type``
+      -  Required. Shall be the error code name, spelled exactly as
+         :doc:`../error_codes/definitions` spells it. Error code names are
+         therefore at most 50 characters long.
+
+   -  -  ``info``
+      -  ``CiString50Type``
+      -  Not used by this document. Reserved.
+
+A charging management system that does not recognise ``vendorId`` ignores
+``vendorId`` and ``vendorErrorCode``, and is left with the ``errorCode``,
+``status`` and ``timestamp`` it would have received anyway. Reporting error
+codes this way therefore does not break an existing OCPP 1.6 deployment, and no
+configuration key is needed to switch it off.
+
+Raising and clearing an error
+=============================
+
+An error code in OCPP 1.6 is a state and not an event: each
+``StatusNotification.req`` replaces whatever the charging management system last
+recorded for that connector, and OCPP 1.6 defines no message that ends an error.
+
+When the reported condition ends, the EVSE shall send a further
+``StatusNotification.req`` for the same ``connectorId`` with ``errorCode`` set
+to ``NoError``, omitting ``vendorId`` and ``vendorErrorCode``, and with
+``status`` set to the status the connector has returned to.
+
+A connector therefore has at most one error code at a time. Where several
+conditions hold at once, the EVSE shall report the one it considers the root
+cause. Reporting several error codes as a correlated group is out of scope in
+this edition.
+
+Example
+=======
+
+A contactor that failed to reach its commanded state, reported against
+connector 1:
+
+.. code-block:: json
+
+   {
+     "connectorId": 1,
+     "errorCode": "PowerSwitchFailure",
+     "status": "Faulted",
+     "timestamp": "2026-09-06T14:32:10Z",
+     "vendorId": "org.charin.uec.v1",
+     "vendorErrorCode": "ContactorPosition"
+   }
+
+The same connector once the condition has ended:
+
+.. code-block:: json
+
+   {
+     "connectorId": 1,
+     "errorCode": "NoError",
+     "status": "Available",
+     "timestamp": "2026-09-06T14:41:02Z"
+   }

--- a/specification/ocpp16/definitions_ErrorCodeMapping16.rst
+++ b/specification/ocpp16/definitions_ErrorCodeMapping16.rst
@@ -1,0 +1,76 @@
+..
+   SPDX-License-Identifier: CC-BY-4.0
+   Copyright CharIN e.V. and Contributors
+
+.. _ocpp16_error_code_mapping:
+
+***********************************
+ Mapping to ChargePointErrorCode
+***********************************
+
+``StatusNotification.req`` requires an ``errorCode`` from a closed enumeration of
+sixteen values, so every error code needs a value to send there while its own
+name travels in ``vendorErrorCode``.
+
+The value is the closest match in meaning, so that a charging management system
+which knows nothing of this document still classifies the report roughly
+correctly. It is a lossy summary and not an identifier: the error code name in
+``vendorErrorCode`` is what identifies the condition.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 34 30 36
+
+   -  -  Error code
+      -  ``ChargePointErrorCode``
+      -  Basis
+
+   -  -  ``ConnectorLockFailure``
+      -  ``ConnectorLockFailure``
+      -  "Failure to lock or unlock connector."
+
+   -  -  ``HighTemperature``
+      -  ``HighTemperature``
+      -  "Temperature inside Charge Point is too high."
+
+   -  -  ``Overvoltage``
+      -  ``OverVoltage``
+      -  "Voltage has risen above an acceptable level."
+
+   -  -  ``OverCurrent``
+      -  ``OverCurrentFailure``
+      -  "Over current protection device has tripped."
+
+   -  -  ``ContactorPosition``
+      -  ``PowerSwitchFailure``
+      -  "Failure to control power switch."
+
+   -  -  ``PowerModuleFault``
+      -  ``InternalError``
+      -  "Error in internal hard- or software component." A power module is a
+         component of the EVSE or the EV, and its failure is internal to the
+         reporting side.
+
+   -  -  ``GridPowerLoss``
+      -  ``OtherError``
+      -  The enumeration has no value for a loss of supply at the grid
+         connection.
+
+   -  -  ``EVShiftPosition``
+      -  ``OtherError``
+      -  The enumeration has no value for a condition detected in the vehicle.
+         ``EVCommunicationError`` is deliberately not used: OCPP 1.6 restricts
+         it to communication problems and to statuses other than ``Faulted``.
+
+An error code that this table does not list shall be reported with ``errorCode``
+set to ``OtherError``.
+
+Four of the eight values above are the ones DIN DKE SPEC 99003 chose for the
+same conditions, so an implementation following both documents reports them
+identically.
+
+.. note::
+
+   This table uses the error code names as normalized by GitHub issue #76.
+   Until that change lands, the catalogue spells ``HighTemperature`` as
+   "High Temperature" and ``OverCurrent`` as ``SideB_OverCurrentFailure``.


### PR DESCRIPTION
Adds the clause saying how an EVSE reports a Unified Error Code to a charging management system over OCPP 1.6, and the table mapping each error code onto the ChargePointErrorCode value that has to accompany it.

The whole report fits in a single StatusNotification.req. The error code name travels in vendorErrorCode, org.charin.uec.v1 in vendorId identifies it as one of ours, and errorCode carries the closest standard value so a system that knows nothing of this document still classifies the report roughly correctly. DIN DKE SPEC 99003 needs a second DataTransfer.req message because it also carries telemetry; with error codes only there is nothing that does not fit, so DataTransfer is left free for a later edition and no configuration key is needed to switch anything off.

It also states how a lasting error is cleared, which OCPP 1.6 has no message for: a further StatusNotification.req with errorCode NoError for the same connector.

Two things worth arguing about. PowerModuleFault maps to InternalError rather than falling through to OtherError, which is what DIN does; and vendorId is org.charin.uec.v1, a reversed DNS name as OCPP 1.6 recommends, rather than the urn form DIN uses.

The mapping table uses the error code names from #76, so that PR and this one should land together; before it lands two rows are ahead of the catalogue.

Both example payloads were validated against the official OCPP 1.6 StatusNotification.json schema, every value in the mapping table was checked against the official ChargePointErrorCode enumeration, and the document builds with no new warnings.

Closes #69
Closes #70