### PR TITLE
Specify error code delivery over OCPP 2.x

### DIFF
--- a/specification/index.rst
+++ b/specification/index.rst
@@ -17,4 +17,5 @@ for electric vehicle charging stations.
    error_codes/definitions_EVShiftPosition
    error_codes/definitions_ContactorPosition
    error_codes/definitions_Overvoltage
+   ocpp2x/definitions
    telemetry/definitions

--- a/specification/ocpp2x/definitions.rst
+++ b/specification/ocpp2x/definitions.rst
@@ -1,0 +1,21 @@
+..
+   SPDX-License-Identifier: CC-BY-4.0
+   Copyright CharIN e.V. and Contributors
+
+###################################
+ Error Code Delivery over OCPP 2.x
+###################################
+
+This section specifies how an EVSE reports an error code defined in
+:doc:`../error_codes/definitions` to a charging management system using
+`OCPP 2.0.1 and OCPP 2.1
+<https://openchargealliance.org/protocols/open-charge-point-protocol/>`_.
+
+It specifies delivery of the error code only. Telemetry is not carried over
+OCPP 2.x by this edition.
+
+Where the two versions differ, this section says so. Everything else applies to
+both.
+
+.. include:: definitions_ErrorCodeDelivery2x.rst
+.. include:: definitions_DeviceModelMapping2x.rst

--- a/specification/ocpp2x/definitions_DeviceModelMapping2x.rst
+++ b/specification/ocpp2x/definitions_DeviceModelMapping2x.rst
@@ -1,0 +1,123 @@
+..
+   SPDX-License-Identifier: CC-BY-4.0
+   Copyright CharIN e.V. and Contributors
+
+.. _ocpp2x_device_model_mapping:
+
+***************************************
+ Mapping to the OCPP 2.x Device Model
+***************************************
+
+OCPP 2.x reports a fault against the device model rather than as an error code,
+so each error code needs a component and a variable to be reported against.
+OCPP 2.x requires a standardized component name to be used wherever one matches
+the physical component being described, which is what makes such a mapping
+possible at all.
+
+The table below gives that mapping. Every component and variable name in it is a
+standardized OCPP 2.x name.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 24 22 14 16 24
+
+   -  -  Error code
+      -  Component
+      -  Variable
+      -  ``actualValue``
+      -  Basis
+
+   -  -  ``ConnectorLockFailure`` (EVSE)
+      -  ``ConnectorPlugRetentionLock``
+      -  ``Problem``
+      -  ``"true"`` / ``"false"``
+      -  OCPP 2.x describes this variable as "Locking Failed" and itself
+         requires this component and variable for a lock failure.
+
+   -  -  ``ConnectorLockFailure`` (EV)
+      -  ``EVRetentionLock``
+      -  ``Problem``
+      -  ``"true"`` / ``"false"``
+      -  "Lock Problem (e.g. failed to lock/unlock)".
+
+   -  -  ``ContactorPosition``
+      -  ``PowerContactor``
+      -  ``Problem``
+      -  ``"true"`` / ``"false"``
+      -  "Close/Open failed".
+
+   -  -  ``HighTemperature``
+      -  ``TemperatureSensor``
+      -  ``Active``
+      -  ``"true"`` / ``"false"``
+      -  ``Active`` on this component means "High temperature (over MaxSet)".
+         ``Problem`` is deliberately not used: on this component it means a
+         fault in the sensor, not an overtemperature.
+
+   -  -  ``PowerModuleFault``
+      -  ``AcDcConverter``
+      -  ``Problem``
+      -  ``"true"`` / ``"false"``
+      -  "some problem/fault exists". Which module failed is carried by
+         ``component.instance``.
+
+   -  -  ``GridPowerLoss``
+      -  ``ElectricalFeed``
+      -  ``Problem``
+      -  ``"true"`` / ``"false"``
+      -  This component "represents an incoming electrical connection to a
+         Charging Station, that may be a grid/distribution network connection".
+
+   -  -  ``OverCurrent``
+      -  ``OverCurrentProtection``
+      -  ``Active``
+      -  ``"true"`` / ``"false"``
+      -  ``Active`` on this component means "Tripped. Trip when over
+         MaxSet/MaxLimit."
+
+   -  -  ``Overvoltage`` (Site A)
+      -  ``ElectricalFeed``
+      -  ``ACVoltage``
+      -  measured voltage
+      -  OCPP 2.x has no overvoltage protection component, so an overvoltage at
+         the supply interface is reported as the measured voltage of the
+         incoming feed.
+
+   -  -  ``Overvoltage`` (Site B)
+      -  ``EVSE``
+      -  ``DCVoltage``
+      -  measured voltage
+      -  The same, at the vehicle interface. ``ACVoltage`` is used instead where
+         the vehicle interface is AC.
+
+   -  -  ``EVShiftPosition``
+      -  ``ConnectedEV``
+      -  ``ChargingState``
+      -  ``"VehicleShiftPosition"``
+      -  ``VehicleShiftPosition`` is a member of the ``ChargingState`` value
+         list, which OCPP 2.x itself maps to ``FAILED_EVShiftPosition`` of
+         ISO 15118-2.
+
+Notes on individual rows
+========================
+
+``ConnectorLockFailure`` has two rows because the error code applies to whichever
+side owns the lock. Which row applies is decided by which side owns the
+mechanism, not by which side reported the condition. Where the EVSE relays a lock
+failure the vehicle reported to it over ISO 15118, the ``ConnectedEV`` component
+with ``ChargingState`` set to ``"ChargerConnectorLockFault"`` may be used
+instead.
+
+``OverCurrent`` is reported against ``OverCurrentProtection`` where the charging
+station models a discrete protection device. Where it does not, the ``EVSE``
+component with the ``Overload`` variable, which OCPP 2.x describes as "Excessive
+current/power consumption", may be used instead.
+
+``Overvoltage`` is the one error code in this table reported as a measured value
+rather than as a boolean state, because OCPP 2.x offers no component whose state
+means "voltage too high". Reporting the voltage itself lets a charging management
+system apply its own monitor to the same variable and reach the same conclusion.
+
+DIN DKE SPEC 99003 states that defining this mapping is outside its scope, so
+there is no earlier mapping to align with. The rows above are derived from the
+descriptions OCPP 2.x gives its own standardized components and variables.

--- a/specification/ocpp2x/definitions_ErrorCodeDelivery2x.rst
+++ b/specification/ocpp2x/definitions_ErrorCodeDelivery2x.rst
@@ -9,7 +9,7 @@
 *******************************
 
 Message
-=======
+=========
 
 An error code is reported in a ``NotifyEventRequest`` message.
 
@@ -140,7 +140,7 @@ touches it is ``EventDataType.severity``, which OCPP 2.1 adds and this document
 does not use.
 
 Example
-=======
+=========
 
 A contactor that failed to reach its commanded state, reported against
 connector 1 of EVSE 1:

--- a/specification/ocpp2x/definitions_ErrorCodeDelivery2x.rst
+++ b/specification/ocpp2x/definitions_ErrorCodeDelivery2x.rst
@@ -1,0 +1,193 @@
+..
+   SPDX-License-Identifier: CC-BY-4.0
+   Copyright CharIN e.V. and Contributors
+
+.. _ocpp2x_error_code_delivery:
+
+*******************************
+ Reporting an Error Code
+*******************************
+
+Message
+=======
+
+An error code is reported in a ``NotifyEventRequest`` message.
+
+OCPP 2.x has no equivalent of the OCPP 1.6 ``ChargePointErrorCode``
+enumeration. ``StatusNotificationRequest`` carries no error information at all
+in OCPP 2.x, and OCPP 2.1 deprecates it. A fault is instead reported against the
+device model, as a component, a variable and the value that variable took.
+
+Reporting an error code over OCPP 2.x therefore takes two things, and this
+section specifies both: which component and variable a given error code is
+reported against, in :ref:`ocpp2x_device_model_mapping`; and where the error
+code name itself travels, so that a charging management system can identify the
+condition without having to infer it from the device model.
+
+Field usage
+===========
+
+The fields below are those of ``EventDataType``, one element of the
+``eventData`` list of ``NotifyEventRequest``.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 24 18 58
+
+   -  -  Field
+      -  Value
+      -  Description
+
+   -  -  ``component``
+      -  ``ComponentType``
+      -  Required. Shall be the component that
+         :ref:`ocpp2x_device_model_mapping` gives for the reported error code.
+         ``evse.id`` and ``evse.connectorId`` shall be set when the condition
+         belongs to one EVSE or one connector rather than to the charging
+         station as a whole. Where a charging station has several instances of
+         a component, ``component.instance`` identifies the affected one.
+
+   -  -  ``variable``
+      -  ``VariableType``
+      -  Required. Shall be the variable that
+         :ref:`ocpp2x_device_model_mapping` gives for the reported error code.
+
+   -  -  ``actualValue``
+      -  string[0..2500]
+      -  Required. The value the variable took, as
+         :ref:`ocpp2x_device_model_mapping` gives it.
+
+   -  -  ``techCode``
+      -  string[0..50]
+      -  Required by this document, optional in OCPP 2.x. Shall be the error
+         code name, spelled exactly as :doc:`../error_codes/definitions` spells
+         it. Error code names are therefore at most 50 characters long.
+
+   -  -  ``techInfo``
+      -  string[0..500]
+      -  Not used by this document. Reserved.
+
+   -  -  ``eventId``
+      -  integer
+      -  Required. Identifies this event so that another event can name it as
+         its cause.
+
+   -  -  ``timestamp``
+      -  dateTime
+      -  Required. The time the condition was detected, in UTC.
+
+   -  -  ``trigger``
+      -  ``EventTriggerEnumType``
+      -  Required. ``Alerting`` for a condition the firmware detects itself and
+         for a threshold that has been passed. ``Delta`` where the report is
+         driven by a configured monitor watching a value change.
+
+   -  -  ``eventNotificationType``
+      -  ``EventNotificationEnumType``
+      -  Required. ``HardWiredNotification`` where the firmware raises the
+         condition itself rather than a configured monitor doing so.
+
+   -  -  ``cleared``
+      -  boolean
+      -  Set to ``true`` on the event that ends a condition. See below.
+
+   -  -  ``cause``
+      -  integer
+      -  Optional. The ``eventId`` of the event considered to be the cause of
+         this one.
+
+   -  -  ``severity``
+      -  integer
+      -  Not used by this document. This field exists only in OCPP 2.1, and
+         severity classification of error codes is out of scope in this
+         edition.
+
+A charging management system that does not recognise the error code name in
+``techCode`` is left with the component, variable and value it would have
+received anyway. Reporting error codes this way therefore adds no message and
+no device model entry that an OCPP 2.x deployment does not already have.
+
+Raising and clearing an error
+=============================
+
+A condition that lasts is reported against a boolean state variable such as
+``Problem``, ``Active`` or ``Overload``. The EVSE shall report it with
+``actualValue`` set to ``"true"`` when the condition begins, and shall report
+the same component and variable again with ``actualValue`` set to ``"false"``
+and ``cleared`` set to ``true`` when it ends.
+
+A condition that is instantaneous or self-resetting is reported once, against
+the ``Operated`` or ``Complete`` variable of the component. OCPP 2.x defines
+those two variables as appearing only in event notifications, where they are
+always true, so no clearing event follows.
+
+A condition detected by crossing a threshold is reported with ``actualValue``
+set to the measured value rather than to a boolean, and is cleared by a further
+event with ``cleared`` set to ``true`` once the value has returned within the
+threshold.
+
+Where several conditions hold at once, the EVSE should report the one it
+considers the root cause first, and may report the others with ``cause`` set to
+the ``eventId`` of that first event. Defining how a charging management system
+is to treat such a group is out of scope in this edition.
+
+Differences between OCPP 2.0.1 and OCPP 2.1
+===========================================
+
+``NotifyEventRequest`` and ``EventDataType`` are otherwise identical in the two
+versions, and this section applies unchanged to both. The one difference that
+touches it is ``EventDataType.severity``, which OCPP 2.1 adds and this document
+does not use.
+
+Example
+=======
+
+A contactor that failed to reach its commanded state, reported against
+connector 1 of EVSE 1:
+
+.. code-block:: json
+
+   {
+     "generatedAt": "2026-09-06T14:32:10Z",
+     "seqNo": 0,
+     "eventData": [
+       {
+         "eventId": 1,
+         "timestamp": "2026-09-06T14:32:10Z",
+         "trigger": "Alerting",
+         "eventNotificationType": "HardWiredNotification",
+         "component": {
+           "name": "PowerContactor",
+           "evse": { "id": 1, "connectorId": 1 }
+         },
+         "variable": { "name": "Problem" },
+         "actualValue": "true",
+         "techCode": "ContactorPosition"
+       }
+     ]
+   }
+
+The same condition once it has ended:
+
+.. code-block:: json
+
+   {
+     "generatedAt": "2026-09-06T14:41:02Z",
+     "seqNo": 0,
+     "eventData": [
+       {
+         "eventId": 2,
+         "timestamp": "2026-09-06T14:41:02Z",
+         "trigger": "Alerting",
+         "eventNotificationType": "HardWiredNotification",
+         "component": {
+           "name": "PowerContactor",
+           "evse": { "id": 1, "connectorId": 1 }
+         },
+         "variable": { "name": "Problem" },
+         "actualValue": "false",
+         "cleared": true,
+         "techCode": "ContactorPosition"
+       }
+     ]
+   }


### PR DESCRIPTION
Adds the clause saying how an EVSE reports a Unified Error Code to a charging management system over OCPP 2.0.1 and 2.1, and the table mapping each error code onto the device model component and variable it is reported against.

OCPP 2.x has no equivalent of the OCPP 1.6 error code enumeration. StatusNotificationRequest carries no error information at all and 2.1 deprecates it; a fault is reported against the device model instead. So an error code needs two things, and this covers both: the component and variable it is reported against, and a place for its own name, which is techCode. Every component and variable in the table is a standardized OCPP 2.x name, checked against the part 2 appendices.

This is the part DIN DKE SPEC 99003 declares out of scope in clause 6.3.1, so there is no earlier mapping to align with and the rows are derived from the descriptions OCPP gives its own components. The ones worth a look are HighTemperature, which uses TemperatureSensor.Active rather than .Problem because Problem on that component means the sensor itself is broken; and Overvoltage, which is reported as a measured voltage rather than a boolean because OCPP has no overvoltage protection component.

It also fixes the event lifecycle OCPP leaves to the implementer and DIN leaves undefined: a lasting condition opens with actualValue true and closes with actualValue false and cleared true.

Both example payloads were validated against the official OCPP 2.1 NotifyEventRequest.json schema and use no field OCPP 2.0.1 lacks. The mapping table uses the error code names from #76. Document builds with no new warnings.

Closes #71
Closes #72