### PR TITLE
Fail the documentation build on Sphinx warnings

### DIFF
--- a/.github/workflows/build-specification-pdf.yml
+++ b/.github/workflows/build-specification-pdf.yml
@@ -18,6 +18,8 @@ jobs:
 
       - name: Build PDF using Sphinx and LaTeX
         uses: docker://sphinxdoc/sphinx-latexpdf:8.2.3
+        env:
+          SPHINXOPTS: "-W --keep-going"
         with:
           args: make -C specification latexpdf
 

--- a/specification/conf.py
+++ b/specification/conf.py
@@ -24,4 +24,3 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', '**/definitions_*.rst']
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 html_theme = 'alabaster'
-html_static_path = ['_static']

--- a/specification/index.rst
+++ b/specification/index.rst
@@ -14,7 +14,4 @@ for electric vehicle charging stations.
    :caption: Contents:
 
    error_codes/definitions
-   error_codes/definitions_EVShiftPosition
-   error_codes/definitions_ContactorPosition
-   error_codes/definitions_Overvoltage
    telemetry/definitions


### PR DESCRIPTION
The PDF workflow succeeded even when Sphinx emitted warnings, which is how two of the eight error codes ended up absent from the built document without anyone noticing. Passing -W --keep-going turns an orphaned file, an undefined label or a short title underline into a build failure, so that cannot happen again.

To start the gate from zero it also clears the two warnings the build already had: html_static_path points at a directory that does not exist and holds nothing the build needs, and three toctree entries point at documents conf.py excludes. That second change overlaps with #74 and #77 — same resolution whichever lands first.

Verified both ways: the build succeeds on this branch, and fails when a dangling reference is added.

Best merged after the other 0.1.0 pull requests, so the gate goes up on a tree that is already clean.

Closes #79